### PR TITLE
Add researcher signup option to Get Started button

### DIFF
--- a/src/components/HeaderActions.tsx
+++ b/src/components/HeaderActions.tsx
@@ -6,13 +6,19 @@ import { useAuth } from "../lib/auth";
 export default function HeaderActions() {
   const { isAuthenticated, signOut } = useAuth();
   const navigate = useNavigate();
+
+  // One ref/menu state to handle both profile and get-started menus
   const [open, setOpen] = React.useState(false);
+  const [getStartedOpen, setGetStartedOpen] = React.useState(false);
   const menuRef = React.useRef<HTMLDivElement | null>(null);
 
   React.useEffect(() => {
     function onDocClick(e: MouseEvent) {
       if (!menuRef.current) return;
-      if (e.target instanceof Node && !menuRef.current.contains(e.target)) setOpen(false);
+      if (e.target instanceof Node && !menuRef.current.contains(e.target)) {
+        setOpen(false);
+        setGetStartedOpen(false);
+      }
     }
     document.addEventListener("click", onDocClick);
     return () => document.removeEventListener("click", onDocClick);
@@ -50,9 +56,37 @@ export default function HeaderActions() {
   }
 
   return (
-    <div className="flex items-center gap-3">
+    <div className="relative flex items-center gap-3" ref={menuRef}>
       <Link to="/patients/login" className="px-4 py-2 text-sm rounded-full border border-blue-600 text-blue-700 hover:bg-blue-50">Sign in</Link>
-      <Link to="/patients/volunteer" className="px-4 py-2 text-sm rounded-full bg-blue-600 text-white hover:bg-blue-700">Get Started</Link>
+      <button
+        className="px-4 py-2 text-sm rounded-full bg-blue-600 text-white hover:bg-blue-700"
+        onClick={() => setGetStartedOpen((v) => !v)}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={getStartedOpen}
+      >
+        Get Started
+      </button>
+      {getStartedOpen && (
+        <div className="absolute right-0 top-full mt-2 w-64 rounded-lg border bg-white shadow-md">
+          <div className="p-2">
+            <Link
+              to="/patients/volunteer"
+              className="block rounded-md px-3 py-2 text-sm hover:bg-gray-50"
+              onClick={() => setGetStartedOpen(false)}
+            >
+              I’m a Patient
+            </Link>
+            <Link
+              to="/providers/create"
+              className="block rounded-md px-3 py-2 text-sm hover:bg-gray-50"
+              onClick={() => setGetStartedOpen(false)}
+            >
+              I’m a Researcher / Site
+            </Link>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/screens/providers/CreateAccount.tsx
+++ b/src/screens/providers/CreateAccount.tsx
@@ -5,18 +5,59 @@ import SiteHeader from "../../components/SiteHeader";
 export default function CreateAccount(): JSX.Element {
   return (
     <div className="min-h-screen bg-white text-gray-900">
-      <SiteHeader />
-      <main className="max-w-md mx-auto px-4 py-10">
-        <h1 className="text-3xl font-semibold mb-2">Create Provider Account</h1>
-        <p className="text-gray-600 mb-6">Create your investigator or site admin account to get started.</p>
-        <form className="space-y-4">
-          <input className="w-full border rounded px-3 py-2" placeholder="Full name" />
-          <input className="w-full border rounded px-3 py-2" placeholder="Work email" type="email" />
-          <input className="w-full border rounded px-3 py-2" placeholder="Organization / Site name" />
-          <input className="w-full border rounded px-3 py-2" placeholder="Password" type="password" />
-          <button className="w-full px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700" type="submit">Create account</button>
-        </form>
-        <p className="text-sm text-gray-600 mt-4">Already have an account? <Link to="/providers/login" className="text-blue-600 hover:underline">Log in</Link></p>
+      <SiteHeader active={undefined} />
+      <main className="max-w-2xl mx-auto px-4 py-12">
+        <h1 className="text-3xl md:text-4xl font-semibold text-center mb-8">Create Clinical Site Account</h1>
+
+        <div className="rounded-2xl border shadow-sm p-6 md:p-8 bg-white">
+          <form className="space-y-5">
+            <div>
+              <label className="block text-sm font-medium mb-1" htmlFor="email">Email Address<span className="text-red-500">*</span></label>
+              <input id="email" name="email" type="email" placeholder="Enter your email" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1" htmlFor="phone">Phone Number<span className="text-red-500">*</span></label>
+              <div className="flex gap-2">
+                <select aria-label="Country" className="w-28 rounded-lg border px-2 py-2 bg-white">
+                  <option>US</option>
+                  <option>CA</option>
+                  <option>UK</option>
+                </select>
+                <input id="phone" name="phone" type="tel" placeholder="+1 (555) 000-0000" className="flex-1 rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium mb-1" htmlFor="firstName">Your First Name<span className="text-red-500">*</span></label>
+                <input id="firstName" name="firstName" placeholder="Enter representative first name" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1" htmlFor="lastName">Your Last Name<span className="text-red-500">*</span></label>
+                <input id="lastName" name="lastName" placeholder="Enter representative last name" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1" htmlFor="password">Password<span className="text-red-500">*</span></label>
+              <input id="password" name="password" type="password" placeholder="Create a secure password" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+              <p className="text-xs text-gray-500 mt-1">Must be at least 8 characters.</p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1" htmlFor="ref">How did you hear about us?</label>
+              <input id="ref" name="ref" placeholder="How did you hear about us?" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+
+            <button className="w-full px-4 py-3 rounded-full bg-blue-600 text-white hover:bg-blue-700" type="submit">Get Started</button>
+          </form>
+          <p className="text-center text-xs text-gray-500 mt-3">
+            By clicking the Sign up button you agree to Trialcliniq's latest <Link to="/patients/privacy" className="text-blue-600 hover:underline">Privacy Policy</Link>.
+          </p>
+        </div>
+
+        <p className="text-sm text-gray-600 mt-6 text-center">Already have an account? <Link to="/providers/login" className="text-blue-600 hover:underline">Sign in</Link></p>
       </main>
     </div>
   );


### PR DESCRIPTION
## Purpose

The user requested that the "Get Started" button provide options for both patients and researchers to sign up, with the researcher option leading to a dedicated signup page. This change improves the user experience by clearly separating the two different user types and their respective onboarding flows.

## Code changes

- **HeaderActions.tsx**: Converted the "Get Started" button from a direct link to a dropdown menu with two options:
  - "I'm a Patient" (existing patient volunteer flow)
  - "I'm a Researcher / Site" (new researcher signup flow)
  - Added state management for the dropdown menu and click-outside handling

- **CreateAccount.tsx**: Enhanced the provider/researcher account creation page with:
  - Improved form layout and styling with better visual hierarchy
  - Added comprehensive form fields (email, phone, first/last name, password, referral source)
  - Enhanced accessibility with proper labels and focus states
  - Added privacy policy agreement and sign-in linkTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 20`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2a2c1d9f4dd2421fbb1d612523d028a5/pixel-field)

👀 [Preview Link](https://2a2c1d9f4dd2421fbb1d612523d028a5-pixel-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2a2c1d9f4dd2421fbb1d612523d028a5</projectId>-->
<!--<branchName>pixel-field</branchName>-->