### PR TITLE
Add site and investigator information pages to provider flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ function App() {
         <Route path="/providers/create" element={<CreateAccount />} />
         <Route path="/providers/login" element={<ProviderLogin />} />
         <Route path="/providers/site-information" element={<SiteInformation />} />
+        <Route path="/providers/investigator-information" element={<InvestigatorInformation />} />
         <Route path="/patients/dashboard" element={<RequireAuth><Dashboard /></RequireAuth>} />
         <Route path="/patients/eligible" element={<RequireAuth><EligibleTrials /></RequireAuth>} />
         <Route path="/patients/health-profile" element={<RequireAuth><HealthProfile /></RequireAuth>} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import InvestigatorSupport from "./screens/support/InvestigatorSupport";
 import CreateAccount from "./screens/providers/CreateAccount";
 import ProviderLogin from "./screens/providers/Login";
 import SiteInformation from "./screens/providers/SiteInformation";
+import InvestigatorInformation from "./screens/providers/InvestigatorInformation";
 import Dashboard from "./screens/patients/Dashboard";
 import TrialDetails from "./screens/TrialDetails";
 import EligibleTrials from "./screens/patients/EligibleTrials";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import MulticenterListings from "./screens/sites/MulticenterListings";
 import InvestigatorSupport from "./screens/support/InvestigatorSupport";
 import CreateAccount from "./screens/providers/CreateAccount";
 import ProviderLogin from "./screens/providers/Login";
+import SiteInformation from "./screens/providers/SiteInformation";
 import Dashboard from "./screens/patients/Dashboard";
 import TrialDetails from "./screens/TrialDetails";
 import EligibleTrials from "./screens/patients/EligibleTrials";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ function App() {
         <Route path="/support/investigators" element={<InvestigatorSupport />} />
         <Route path="/providers/create" element={<CreateAccount />} />
         <Route path="/providers/login" element={<ProviderLogin />} />
+        <Route path="/providers/site-information" element={<SiteInformation />} />
         <Route path="/patients/dashboard" element={<RequireAuth><Dashboard /></RequireAuth>} />
         <Route path="/patients/eligible" element={<RequireAuth><EligibleTrials /></RequireAuth>} />
         <Route path="/patients/health-profile" element={<RequireAuth><HealthProfile /></RequireAuth>} />

--- a/src/screens/providers/CreateAccount.tsx
+++ b/src/screens/providers/CreateAccount.tsx
@@ -1,8 +1,15 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import SiteHeader from "../../components/SiteHeader";
 
 export default function CreateAccount(): JSX.Element {
+  const navigate = useNavigate();
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    navigate("/providers/site-information");
+  }
+
   return (
     <div className="min-h-screen bg-white text-gray-900">
       <SiteHeader active={undefined} />
@@ -10,7 +17,7 @@ export default function CreateAccount(): JSX.Element {
         <h1 className="text-3xl md:text-4xl font-semibold text-center mb-8">Create Clinical Site Account</h1>
 
         <div className="rounded-2xl border shadow-sm p-6 md:p-8 bg-white">
-          <form className="space-y-5">
+          <form className="space-y-5" onSubmit={handleSubmit}>
             <div>
               <label className="block text-sm font-medium mb-1" htmlFor="email">Email Address<span className="text-red-500">*</span></label>
               <input id="email" name="email" type="email" placeholder="Enter your email" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />

--- a/src/screens/providers/InvestigatorInformation.tsx
+++ b/src/screens/providers/InvestigatorInformation.tsx
@@ -1,0 +1,96 @@
+import { useNavigate } from "react-router-dom";
+import SiteHeader from "../../components/SiteHeader";
+
+export default function InvestigatorInformation(): JSX.Element {
+  const navigate = useNavigate();
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    navigate("/providers/login");
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      <SiteHeader active={undefined} />
+      <main className="max-w-3xl mx-auto px-4 py-10">
+        <h1 className="text-3xl md:text-4xl font-semibold text-center">Investigator Information</h1>
+        <p className="text-center text-gray-600 mt-2">Enter your site's contact and location details for trial coordination</p>
+
+        <div className="mt-8 rounded-2xl border shadow-sm bg-white p-6 md:p-8">
+          <form className="space-y-5" onSubmit={handleSubmit}>
+            <div>
+              <label className="block text-sm font-medium mb-1">Investigator Name<span className="text-red-500">*</span></label>
+              <input placeholder="Enter full name of the site investigator" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+              <label className="mt-2 flex items-center gap-2 text-sm">
+                <input type="radio" name="useMyName" className="h-4 w-4" />
+                Use my name as investigator
+              </label>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Affiliated Organization Name<span className="text-gray-500">*</span></label>
+              <input placeholder="Enter the affiliated organization name" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+              <label className="mt-2 flex items-center gap-2 text-sm">
+                <input type="radio" name="sameOrg" className="h-4 w-4" />
+                Same as sponsoring organization
+              </label>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Investigator Phone<span className="text-gray-500">*</span></label>
+              <input placeholder="Enter the primary phone number for the investigator" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+              <label className="mt-2 flex items-center gap-2 text-sm">
+                <input type="radio" name="useMyPhone" className="h-4 w-4" />
+                Use my phone number
+              </label>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Investigator Email<span className="text-gray-500">*</span></label>
+              <input type="email" placeholder="Enter the primary email address for the investigator" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+              <label className="mt-2 flex items-center gap-2 text-sm">
+                <input type="radio" name="useMyEmail" className="h-4 w-4" />
+                Use my email address
+              </label>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Regulatory Authority</label>
+              <input placeholder="Enter the regulatory authority overseeing the trials" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Regulatory Authority Address</label>
+              <input placeholder="Enter the full mailing address of the regulatory authority" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+
+            <div className="space-y-3 text-sm text-gray-700">
+              <p>
+                By registering, you consent to receive trial match leads and communication updates from TrialCliniq. Your site, investigator and admin data will be securely stored in compliance with HIPAA standards and will be used solely for trial matching and engagement services within this platform.
+              </p>
+              <label className="flex items-center gap-2">
+                <input type="checkbox" className="h-4 w-4 rounded border" />
+                I consent to the use of my professional and site data as described.
+              </label>
+              <label className="flex items-center gap-2">
+                <input type="checkbox" className="h-4 w-4 rounded border" />
+                I agree to receive email and SMS notifications for trial match leads and platform updates.
+              </label>
+              <p className="flex items-center gap-2 text-xs text-gray-500">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4"><path d="M12 2a9 9 0 1 0 9 9A9.01 9.01 0 0 0 12 2Zm1 13h-2v-2h2Zm0-4h-2V7h2Z"/></svg>
+                You may revoke consent at any time in Settings
+              </p>
+            </div>
+
+            <button type="submit" className="mt-2 w-full px-6 py-3 rounded-full bg-blue-600 text-white hover:bg-blue-700">Create Account</button>
+
+            <p className="text-xs text-gray-500 flex items-center gap-2 mt-2">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4"><path d="M12 2a9 9 0 1 0 9 9A9.01 9.01 0 0 0 12 2Zm1 13h-2v-2h2Zm0-4h-2V7h2Z"/></svg>
+              Your data stays private and protected with HIPAA-compliant security.
+            </p>
+          </form>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/screens/providers/SiteInformation.tsx
+++ b/src/screens/providers/SiteInformation.tsx
@@ -1,0 +1,134 @@
+import { Link, useNavigate } from "react-router-dom";
+import SiteHeader from "../../components/SiteHeader";
+
+export default function SiteInformation(): JSX.Element {
+  const navigate = useNavigate();
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    navigate("/providers/login");
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      <SiteHeader active={undefined} />
+      <main className="max-w-3xl mx-auto px-4 py-10">
+        <h1 className="text-3xl md:text-4xl font-semibold text-center">Site Information</h1>
+        <p className="text-center text-gray-600 mt-2">Enter your site's contact and location details for trial coordination</p>
+
+        <div className="mt-8 rounded-2xl border shadow-sm bg-white p-6 md:p-8">
+          <form className="space-y-5" onSubmit={handleSubmit}>
+            <div>
+              <label className="block text-sm font-medium mb-1">Sponsoring Organization Type<span className="text-red-500">*</span></label>
+              <select className="w-full rounded-lg border px-3 py-2 bg-white">
+                <option value="">Select your organization type</option>
+                <option>Hospital / Health System</option>
+                <option>Academic Medical Center</option>
+                <option>Private Practice</option>
+                <option>Research Site Network</option>
+                <option>Other</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Sponsoring Organization Abbreviations</label>
+              <input placeholder="Enter your organization acronym or abbreviation" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Parent Organizations</label>
+              <input placeholder="Enter your parent organization if applicable" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Site Name<span className="text-red-500">*</span></label>
+              <input placeholder="Enter your site name" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium mb-1">Country<span className="text-red-500">*</span></label>
+                <select className="w-full rounded-lg border px-3 py-2 bg-white">
+                  <option value="">Select country</option>
+                  <option>United States</option>
+                  <option>Canada</option>
+                  <option>United Kingdom</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">State<span className="text-red-500">*</span></label>
+                <select className="w-full rounded-lg border px-3 py-2 bg-white">
+                  <option value="">Select state</option>
+                  <option>California</option>
+                  <option>New York</option>
+                  <option>Texas</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium mb-1">Address<span className="text-red-500">*</span></label>
+                <input placeholder="Enter site full address" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Zipcode<span className="text-red-500">*</span></label>
+                <input placeholder="Enter zipcode" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Facility Type<span className="text-red-500">*</span></label>
+              <select className="w-full rounded-lg border px-3 py-2 bg-white">
+                <option value="">Select site type</option>
+                <option>Outpatient Clinic</option>
+                <option>Inpatient Facility</option>
+                <option>Community Site</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Funding Organization<span className="text-red-500">*</span></label>
+              <select className="w-full rounded-lg border px-3 py-2 bg-white">
+                <option value="">Select your organization type</option>
+                <option>Public</option>
+                <option>Private</option>
+                <option>Mixed</option>
+              </select>
+              <label className="mt-2 flex items-center gap-2 text-sm">
+                <input type="checkbox" className="h-4 w-4 rounded border" />
+                Same as sponsoring organization
+              </label>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Conditions Your Site Accepts<span className="text-red-500">*</span></label>
+              <div className="flex items-start gap-2 rounded-full border px-3 py-2">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="mt-1 text-gray-500"><path d="M21 21l-4.35-4.35" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/><circle cx="10" cy="10" r="7" stroke="currentColor" strokeWidth="2"/></svg>
+                <input placeholder="You can add as many as apply. If you're unsure of the exact name, type what you know, we'll help match it." className="flex-1 outline-none text-sm" />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Languages spoken at site<span className="text-red-500">*</span></label>
+              <div className="flex items-start gap-2 rounded-full border px-3 py-2">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="mt-1 text-gray-500"><path d="M21 21l-4.35-4.35" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/><circle cx="10" cy="10" r="7" stroke="currentColor" strokeWidth="2"/></svg>
+                <input placeholder="You can add as many as apply. If you're unsure of the exact name, type what you know, we'll help match it." className="flex-1 outline-none text-sm" />
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between pt-2">
+              <Link to="/providers/create" className="px-6 py-3 rounded-full border bg-white hover:bg-gray-50">Back</Link>
+              <button type="submit" className="px-6 py-3 rounded-full bg-blue-600 text-white hover:bg-blue-700">Continue</button>
+            </div>
+
+            <p className="text-xs text-gray-500 flex items-center gap-2 mt-2">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4"><path d="M12 2a9 9 0 1 0 9 9A9.01 9.01 0 0 0 12 2Zm1 13h-2v-2h2Zm0-4h-2V7h2Z"/></svg>
+              Your data stays private and protected with HIPAA-compliant security.
+            </p>
+          </form>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/screens/providers/SiteInformation.tsx
+++ b/src/screens/providers/SiteInformation.tsx
@@ -6,7 +6,7 @@ export default function SiteInformation(): JSX.Element {
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    navigate("/providers/login");
+    navigate("/providers/investigator-information");
   }
 
   return (


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR implements a multi-step provider registration flow. Users requested that after the "Create Clinical Site Account" page, the flow should navigate to a "Site Information" page, and after that page, it should lead to an "Investigator Information" page to complete the registration process.

## Code changes

- **Added new routes**: Created `/providers/site-information` and `/providers/investigator-information` routes in App.tsx
- **Created SiteInformation component**: New form page collecting site details including organization type, location, facility type, conditions accepted, and languages spoken
- **Created InvestigatorInformation component**: New form page collecting investigator details, contact information, regulatory authority data, and consent checkboxes
- **Updated CreateAccount component**: Added form submission handler that navigates to the site information page
- **Implemented navigation flow**: 
  - Create Account → Site Information → Investigator Information → Login
  - Added back navigation from Site Information to Create Account
  - Final submission from Investigator Information leads to login pageTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 21`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2a2c1d9f4dd2421fbb1d612523d028a5/spark-field)

👀 [Preview Link](https://2a2c1d9f4dd2421fbb1d612523d028a5-spark-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2a2c1d9f4dd2421fbb1d612523d028a5</projectId>-->
<!--<branchName>spark-field</branchName>-->