### PR TITLE
Add EHR directory and unify signup forms

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import Settings from "./screens/patients/Settings";
 import EligibilityCheck from "./screens/patients/EligibilityCheck";
 import EligibilityResult from "./screens/patients/EligibilityResult";
 import ContactUs from "./screens/support/ContactUs";
+import EhrDirectory from "./screens/patients/EhrDirectory";
 import Consent from "./screens/patients/Consent";
 import Connect from "./screens/patients/Connect";
 import { RequireAuth, RequireRole } from "./lib/auth";
@@ -45,6 +46,7 @@ function App() {
         <Route path="/patients/volunteer" element={<Volunteer />} />
         <Route path="/patients/consent" element={<Consent />} />
         <Route path="/patients/connect" element={<Connect />} />
+        <Route path="/patients/ehr" element={<EhrDirectory />} />
         <Route path="/patients/check" element={<EligibilityCheck />} />
         <Route path="/patients/result" element={<EligibilityResult />} />
         <Route path="/patients/login" element={<Login />} />

--- a/src/components/SignUpForm.tsx
+++ b/src/components/SignUpForm.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+export type SignUpFormProps = {
+  title: string;
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  signInPath: string;
+  privacyPath: string;
+};
+
+export default function SignUpForm({ title, onSubmit, signInPath, privacyPath }: SignUpFormProps): JSX.Element {
+  return (
+    <main className="max-w-2xl mx-auto px-4 py-12">
+      <h1 className="text-3xl md:text-4xl font-semibold text-center mb-8">{title}</h1>
+
+      <div className="rounded-2xl border shadow-sm p-6 md:p-8 bg-white">
+        <form className="space-y-5" onSubmit={onSubmit}>
+          <div>
+            <label className="block text-sm font-medium mb-1" htmlFor="email">Email Address<span className="text-red-500">*</span></label>
+            <input id="email" name="email" type="email" placeholder="Enter your email" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1" htmlFor="phone">Phone Number<span className="text-red-500">*</span></label>
+            <div className="flex gap-2">
+              <select aria-label="Country" className="w-28 rounded-lg border px-2 py-2 bg-white">
+                <option>US</option>
+                <option>CA</option>
+                <option>UK</option>
+              </select>
+              <input id="phone" name="phone" type="tel" placeholder="+1 (555) 000-0000" className="flex-1 rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium mb-1" htmlFor="firstName">Your First Name<span className="text-red-500">*</span></label>
+              <input id="firstName" name="firstName" placeholder="Enter representative first name" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1" htmlFor="lastName">Your Last Name<span className="text-red-500">*</span></label>
+              <input id="lastName" name="lastName" placeholder="Enter representative last name" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1" htmlFor="password">Password<span className="text-red-500">*</span></label>
+            <input id="password" name="password" type="password" placeholder="Create a secure password" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+            <p className="text-xs text-gray-500 mt-1">Must be at least 8 characters.</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1" htmlFor="ref">How did you hear about us?</label>
+            <input id="ref" name="ref" placeholder="How did you hear about us?" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          </div>
+
+          <button className="w-full px-4 py-3 rounded-full bg-blue-600 text-white hover:bg-blue-700" type="submit">Get Started</button>
+        </form>
+        <p className="text-center text-xs text-gray-500 mt-3">
+          By clicking the Sign up button you agree to Trialcliniq's latest <Link to={privacyPath} className="text-blue-600 hover:underline">Privacy Policy</Link>.
+        </p>
+      </div>
+
+      <p className="text-sm text-gray-600 mt-6 text-center">Already have an account? <Link to={signInPath} className="text-blue-600 hover:underline">Sign in</Link></p>
+    </main>
+  );
+}

--- a/src/routes/Home2/screens/Home.tsx
+++ b/src/routes/Home2/screens/Home.tsx
@@ -110,7 +110,7 @@ export default function Home() {
                 <div className="font-semibold">Match your Electronic Health Record (EHR) to trials</div>
                 <div className="text-gray-600">Import your EHR to browse trials that fit your medical history and lab results — securely and with your consent.</div>
               </div>
-              <Link to="/search-results" className="ml-auto inline-flex items-center gap-2 rounded-full bg-gray-900 px-4 py-2 text-white text-sm hover:bg-black">
+              <Link to="/patients/ehr" className="ml-auto inline-flex items-center gap-2 rounded-full bg-gray-900 px-4 py-2 text-white text-sm hover:bg-black">
                 Connect to Trial Portal
                 <ArrowRight className="h-4 w-4" />
               </Link>

--- a/src/screens/patients/Connect.tsx
+++ b/src/screens/patients/Connect.tsx
@@ -72,7 +72,7 @@ export default function Connect(): JSX.Element {
             <div className="flex-1">
               <div className="font-medium">Match your Electronic Health Record (EHR) to trials</div>
               <p className="text-sm text-gray-600">Import your EHR to browse trials that fit your medical history and lab results with your consent.</p>
-              <button type="button" onClick={()=>navigate("/search-results")} className="mt-3 inline-flex items-center gap-2 rounded-full bg-gray-900 px-4 py-2 text-white text-sm hover:bg-black">Connect to Trial Portal →</button>
+              <button type="button" onClick={()=>navigate("/patients/ehr")} className="mt-3 inline-flex items-center gap-2 rounded-full bg-gray-900 px-4 py-2 text-white text-sm hover:bg-black">Connect to Trial Portal →</button>
             </div>
           </div>
         </div>

--- a/src/screens/patients/EhrDirectory.tsx
+++ b/src/screens/patients/EhrDirectory.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import SiteHeader from "../../components/SiteHeader";
+
+export type EhrItem = {
+  id: string;
+  vendor: string;
+  organization: string;
+  portals: number;
+};
+
+const ALL_EHRS: EhrItem[] = [
+  { id: "1", vendor: "MEDITECH Expanse", organization: "Citizens Medical Center", portals: 1 },
+  { id: "2", vendor: "athenahealth", organization: "Texas Endovascular Associates", portals: 1 },
+  { id: "3", vendor: "Epic", organization: "MD Anderson Cancer Center", portals: 2 },
+  { id: "4", vendor: "Oracle", organization: "Mount Sinai Health System", portals: 1 },
+  { id: "5", vendor: "MEDITECH Expanse", organization: "Citizens Medical Center", portals: 1 },
+  { id: "6", vendor: "athenahealth", organization: "Texas Endovascular Associates", portals: 1 },
+  { id: "7", vendor: "Epic", organization: "MD Anderson Cancer Center", portals: 2 },
+  { id: "8", vendor: "Oracle", organization: "Mount Sinai Health System", portals: 1 },
+  { id: "9", vendor: "MEDITECH Expanse", organization: "Citizens Medical Center", portals: 1 },
+  { id: "10", vendor: "athenahealth", organization: "Texas Endovascular Associates", portals: 1 },
+  { id: "11", vendor: "Epic", organization: "MD Anderson Cancer Center", portals: 2 },
+  { id: "12", vendor: "Oracle", organization: "Mount Sinai Health System", portals: 1 },
+  { id: "13", vendor: "MEDITECH Expanse", organization: "Citizens Medical Center", portals: 1 },
+  { id: "14", vendor: "athenahealth", organization: "Texas Endovascular Associates", portals: 1 },
+  { id: "15", vendor: "Epic", organization: "MD Anderson Cancer Center", portals: 2 },
+  { id: "16", vendor: "Oracle", organization: "Mount Sinai Health System", portals: 1 },
+  { id: "17", vendor: "MEDITECH Expanse", organization: "Citizens Medical Center", portals: 1 },
+  { id: "18", vendor: "athenahealth", organization: "Texas Endovascular Associates", portals: 1 },
+  { id: "19", vendor: "Epic", organization: "MD Anderson Cancer Center", portals: 2 },
+  { id: "20", vendor: "Oracle", organization: "Mount Sinai Health System", portals: 1 },
+  { id: "21", vendor: "MEDITECH Expanse", organization: "Citizens Medical Center", portals: 1 },
+  { id: "22", vendor: "athenahealth", organization: "Texas Endovascular Associates", portals: 1 },
+  { id: "23", vendor: "Epic", organization: "MD Anderson Cancer Center", portals: 2 },
+  { id: "24", vendor: "Oracle", organization: "Mount Sinai Health System", portals: 1 },
+];
+
+function Card({ item }: { item: EhrItem }) {
+  return (
+    <div className="rounded-xl border p-4 bg-white">
+      <div className="flex items-start gap-3">
+        <div className="h-8 w-8 grid place-items-center rounded bg-gray-100 text-gray-700 text-xs font-semibold">
+          {item.vendor.split(" ")[0]}
+        </div>
+        <div className="flex-1">
+          <div className="text-sm text-gray-500">{item.vendor}</div>
+          <div className="font-medium leading-5">{item.organization}</div>
+          <button className="mt-2 inline-flex items-center text-xs rounded-full bg-blue-50 text-blue-700 px-2 py-1">{item.portals} portal{item.portals>1?"s":""}</button>
+        </div>
+        <button aria-label="Add" className="ml-auto h-7 w-7 grid place-items-center rounded border text-gray-700">+</button>
+      </div>
+    </div>
+  );
+}
+
+export default function EhrDirectory(): JSX.Element {
+  const [q, setQ] = React.useState("");
+  const [visible, setVisible] = React.useState(12);
+
+  const filtered = React.useMemo(() => {
+    const t = q.trim().toLowerCase();
+    if (!t) return ALL_EHRS;
+    return ALL_EHRS.filter((i) =>
+      i.vendor.toLowerCase().includes(t) || i.organization.toLowerCase().includes(t)
+    );
+  }, [q]);
+
+  const items = filtered.slice(0, visible);
+  const canLoadMore = visible < filtered.length;
+
+  return (
+    <div className="min-h-screen bg-white text-gray-900">
+      <SiteHeader />
+      <main className="max-w-6xl mx-auto px-4 py-10">
+        <h1 className="text-xl font-semibold">Available EMR/EHRs</h1>
+        <p className="text-sm text-gray-600 mt-1">Securely connect your health record to help TrialCliniq match you with the most relevant clinical trials</p>
+
+        <div className="mt-4">
+          <div className="relative max-w-xl">
+            <input
+              value={q}
+              onChange={(e)=>setQ(e.target.value)}
+              placeholder="Search healthcare systems or providers"
+              className="w-full rounded-full border px-4 py-2 pl-10"
+            />
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">🔎</span>
+          </div>
+        </div>
+
+        <div className="mt-5 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          {items.map((i) => (
+            <Card key={i.id+"-"+visible} item={i} />
+          ))}
+        </div>
+
+        <div className="mt-6">
+          {canLoadMore ? (
+            <div className="max-w-xl mx-auto">
+              <button
+                type="button"
+                onClick={() => setVisible((v) => Math.min(v + 9, filtered.length))}
+                className="w-full rounded-full border px-4 py-2 hover:bg-gray-50"
+              >
+                Load more
+              </button>
+            </div>
+          ) : (
+            <div className="text-center text-sm text-gray-500">No more results</div>
+          )}
+        </div>
+
+        <div className="mt-8 flex items-center justify-end text-xs text-gray-500">
+          <span>Powered by Health Gorilla</span>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/screens/patients/Volunteer.tsx
+++ b/src/screens/patients/Volunteer.tsx
@@ -1,28 +1,25 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import SiteHeader from "../../components/SiteHeader";
+import SignUpForm from "../../components/SignUpForm";
 
 export default function Volunteer(): JSX.Element {
   const navigate = useNavigate();
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    navigate("/patients/consent");
+  }
+
   return (
     <div className="min-h-screen bg-white text-gray-900">
       <SiteHeader />
-      <main className="max-w-3xl mx-auto px-4 py-10">
-        <h1 className="text-3xl font-semibold mb-4">Become a clinical trial volunteer</h1>
-        <p className="text-gray-700 mb-6">Create an account to receive personalized trial matches based on your health profile and location.</p>
-        <form
-          className="space-y-4"
-          onSubmit={(e) => {
-            e.preventDefault();
-            navigate("/patients/consent");
-          }}
-        >
-          <input className="w-full border rounded px-3 py-2" placeholder="Full name" />
-          <input className="w-full border rounded px-3 py-2" placeholder="Email" type="email" />
-          <input className="w-full border rounded px-3 py-2" placeholder="Location (city, state)" />
-          <button className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700" type="submit">Sign up</button>
-        </form>
-      </main>
+      <SignUpForm
+        title="Create Patient Account"
+        onSubmit={handleSubmit}
+        privacyPath="/patients/privacy"
+        signInPath="/patients/login"
+      />
     </div>
   );
 }

--- a/src/screens/providers/CreateAccount.tsx
+++ b/src/screens/providers/CreateAccount.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import SiteHeader from "../../components/SiteHeader";
+import SignUpForm from "../../components/SignUpForm";
 
 export default function CreateAccount(): JSX.Element {
   const navigate = useNavigate();
@@ -13,59 +14,12 @@ export default function CreateAccount(): JSX.Element {
   return (
     <div className="min-h-screen bg-white text-gray-900">
       <SiteHeader active={undefined} />
-      <main className="max-w-2xl mx-auto px-4 py-12">
-        <h1 className="text-3xl md:text-4xl font-semibold text-center mb-8">Create Clinical Site Account</h1>
-
-        <div className="rounded-2xl border shadow-sm p-6 md:p-8 bg-white">
-          <form className="space-y-5" onSubmit={handleSubmit}>
-            <div>
-              <label className="block text-sm font-medium mb-1" htmlFor="email">Email Address<span className="text-red-500">*</span></label>
-              <input id="email" name="email" type="email" placeholder="Enter your email" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium mb-1" htmlFor="phone">Phone Number<span className="text-red-500">*</span></label>
-              <div className="flex gap-2">
-                <select aria-label="Country" className="w-28 rounded-lg border px-2 py-2 bg-white">
-                  <option>US</option>
-                  <option>CA</option>
-                  <option>UK</option>
-                </select>
-                <input id="phone" name="phone" type="tel" placeholder="+1 (555) 000-0000" className="flex-1 rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
-              </div>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium mb-1" htmlFor="firstName">Your First Name<span className="text-red-500">*</span></label>
-                <input id="firstName" name="firstName" placeholder="Enter representative first name" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
-              </div>
-              <div>
-                <label className="block text-sm font-medium mb-1" htmlFor="lastName">Your Last Name<span className="text-red-500">*</span></label>
-                <input id="lastName" name="lastName" placeholder="Enter representative last name" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
-              </div>
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium mb-1" htmlFor="password">Password<span className="text-red-500">*</span></label>
-              <input id="password" name="password" type="password" placeholder="Create a secure password" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
-              <p className="text-xs text-gray-500 mt-1">Must be at least 8 characters.</p>
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium mb-1" htmlFor="ref">How did you hear about us?</label>
-              <input id="ref" name="ref" placeholder="How did you hear about us?" className="w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
-            </div>
-
-            <button className="w-full px-4 py-3 rounded-full bg-blue-600 text-white hover:bg-blue-700" type="submit">Get Started</button>
-          </form>
-          <p className="text-center text-xs text-gray-500 mt-3">
-            By clicking the Sign up button you agree to Trialcliniq's latest <Link to="/patients/privacy" className="text-blue-600 hover:underline">Privacy Policy</Link>.
-          </p>
-        </div>
-
-        <p className="text-sm text-gray-600 mt-6 text-center">Already have an account? <Link to="/providers/login" className="text-blue-600 hover:underline">Sign in</Link></p>
-      </main>
+      <SignUpForm
+        title="Create Clinical Site Account"
+        onSubmit={handleSubmit}
+        privacyPath="/patients/privacy"
+        signInPath="/providers/login"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses two main requirements:
1. Standardize the patient and researcher signup forms to use the same template with only different wording at the top
2. Create an EHR directory screen accessible from the "Connect to Trial Portal" button on the home page, with load more functionality

## Code changes

- **Created reusable SignUpForm component** (`src/components/SignUpForm.tsx`) with configurable title, submit handler, and navigation paths
- **Refactored patient signup** (`src/screens/patients/Volunteer.tsx`) to use the new SignUpForm component with "Create Patient Account" title
- **Refactored provider signup** (`src/screens/providers/CreateAccount.tsx`) to use the same SignUpForm component with "Create Clinical Site Account" title
- **Added EHR directory screen** (`src/screens/patients/EhrDirectory.tsx`) with search functionality, paginated results, and load more button
- **Updated routing** in `src/App.tsx` to include the new EHR directory route at `/patients/ehr`
- **Updated navigation links** in home page and connect screen to point to the new EHR directory instead of search resultsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 30`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2a2c1d9f4dd2421fbb1d612523d028a5/zenith-garden)

👀 [Preview Link](https://2a2c1d9f4dd2421fbb1d612523d028a5-zenith-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2a2c1d9f4dd2421fbb1d612523d028a5</projectId>-->
<!--<branchName>zenith-garden</branchName>-->